### PR TITLE
Fix breathe bugs

### DIFF
--- a/Client/src/routes/BreatheRoute.tsx
+++ b/Client/src/routes/BreatheRoute.tsx
@@ -43,7 +43,7 @@ export const BreatheRoute = () => {
       console.log(res);
       //alert(`request succesful: ` + res.status);
       // app navigates to mapRoute after request to halt the physical installation executes correctly.
-      navigate("/intro");
+      navigate("/mapRoute");
     } catch (error: any) {
       alert(error.message);
       console.error(error);
@@ -75,7 +75,7 @@ export const BreatheRoute = () => {
       <button
         className="breathe-route-nav-button"
         onClick={() => {
-          navigate("/mapRoute");
+          makeApiRequest();
         }}
       >
         Go back to the map page

--- a/Client/src/routes/CompareCitiesRoute.tsx
+++ b/Client/src/routes/CompareCitiesRoute.tsx
@@ -73,22 +73,20 @@ const CompareCitiesRoute = () => {
   const handleNextCityButtonClick = async () => {
     if (breathingStage == CompareCitiesBreathingStage.FIRST_CITY) {
       if (selectedCity) {
-      try {
-        const res = await axios.post(
-          `http://localhost:3001/aqi?value=${selectedCity.aqiRating}`
-        );
-        console.log(res);
-        setBreathingStage(CompareCitiesBreathingStage.SECOND_CITY);
-      } catch (error: any) {
-        alert(error.message);
-        console.error(error);
-      }
+        try {
+          const res = await axios.post(
+            `http://localhost:3001/aqi?value=${selectedCity.aqiRating}`
+          );
+          console.log(res);
+          setBreathingStage(CompareCitiesBreathingStage.SECOND_CITY);
+        } catch (error: any) {
+          alert(error.message);
+          console.error(error);
+        }
       }
     } else if (breathingStage == CompareCitiesBreathingStage.SECOND_CITY) {
       try {
-        const res = await axios.post(
-          `http://localhost:3001/aqi?value=${vancouverData.aqiRating}`
-        );
+        const res = await axios.post(`http://localhost:3001/command?command=s`);
         console.log(res);
         setBreathingStage(CompareCitiesBreathingStage.COMPLETION);
       } catch (error: any) {
@@ -96,14 +94,7 @@ const CompareCitiesRoute = () => {
         console.error(error);
       }
     } else {
-      try {
-        const res = await axios.post(`http://localhost:3001/command?command=s`);
-        console.log(res);
-        navigate("/take-action");
-      } catch (error: any) {
-        alert(error.message);
-        console.error(error);
-      }
+      navigate("/take-action");
     }
   };
 


### PR DESCRIPTION
Bugs identified:
- on the city comparison, when the second city runs, pressing on Next sets the aqi command to 1 instead of 0
- from the single-city map selection, the Go Back To Map should send a 0 (stop) command like when the timer  is up, but the city keeps running